### PR TITLE
inner source hugo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - SEO & Performance Optimization
 
 ## Quick Start
-Use this template: [geekifan/chirpy-starter](https://github.com/geekifan/chirpy-starter)
+Use this template: [kewalaka/chirpy-starter](https://github.com/kewalaka/chirpy-starter)
 
 ## Documentation
 
@@ -50,12 +50,14 @@ to learn, inspire, and create. Any contributions you make are greatly appreciate
 
 Thanks to the theme [Chirpy Jekyll Theme][chirpy-jekyll] and all its contributors.
 
+Thanks to [geekifan](https://github.com/geekifan/) for the port to Hugo.
+
 ## License
 
 This project is published under [MIT License][license].
 
 [chirpy-jekyll]: https://github.com/cotes2020/jekyll-theme-chirpy
-[license]: https://github.com/geekifan/hugo-theme-chirpy/blob/main/LICENSE
+[license]: https://github.com/kewalaka/hugo-theme-chirpy/blob/main/LICENSE
 [hugo]: https://gohugo.io/
-[demo]: https://geekifan.github.io/chirpy-starter
-[wiki]: https://geekifan.github.io/chirpy-starter
+[demo]: https://kewalaka.github.io/chirpy-starter
+[wiki]: https://kewalaka.github.io/chirpy-starter

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -7,7 +7,7 @@ author = "yifan"
 
 [social]
   name = "Yifan"
-  url = "https://github.com/geekifan"
+  url = "https://github.com/kewalaka"
 
 [[social.links]]
   type = "github"

--- a/exampleSite/content/about/index.en.md
+++ b/exampleSite/content/about/index.en.md
@@ -10,7 +10,7 @@ menu:
     pre: fa-info-circle
 ---
 
-[Chirpy](https://github.com/cotes2020/jekyll-theme-chirpy) is a blog theme originally based on [Jekyll](https://jekyllrb.com/). Due to Jekyll's design limitations, it does not natively support internationalization (i18n) and requires third-party plugins for i18n functionality. To enable i18n support for Chirpy without the hassle of relying on third-party plugins, the [hugo-theme-chirpy](https://github.com/geekifan/hugo-theme-chirpy) project migrated the Chirpy theme to [Hugo](https://gohugo.io/) with minimal adaptations. All features of Chirpy are available in hugo-theme-chirpy (though some functionalities may operate differently within the Hugo framework).
+[Chirpy](https://github.com/cotes2020/jekyll-theme-chirpy) is a blog theme originally based on [Jekyll](https://jekyllrb.com/). Due to Jekyll's design limitations, it does not natively support internationalization (i18n) and requires third-party plugins for i18n functionality. To enable i18n support for Chirpy without the hassle of relying on third-party plugins, the [hugo-theme-chirpy](https://github.com/kewalaka/hugo-theme-chirpy) project migrated the Chirpy theme to [Hugo](https://gohugo.io/) with minimal adaptations. All features of Chirpy are available in hugo-theme-chirpy (though some functionalities may operate differently within the Hugo framework).
 
 Follow the posts in the demo site to quickly set up a free personal blog!
 ## Features

--- a/exampleSite/content/about/index.zh-CN.md
+++ b/exampleSite/content/about/index.zh-CN.md
@@ -10,7 +10,7 @@ menu:
     pre: fa-info-circle
 ---
 
-[Chirpy](https://github.com/cotes2020/jekyll-theme-chirpy) 是一个基于 [Jekyll](https://jekyllrb.com/) 的博客主题。由于 Jekyll 的设计限制，它本身不支持国际化（i18n），需要依赖第三方插件来实现 i18n 功能。为了让 Chirpy 在不依赖第三方插件的情况下支持 i18n，[hugo-theme-chirpy](https://github.com/geekifan/hugo-theme-chirpy) 项目将 Chirpy 主题迁移至 [Hugo](https://gohugo.io/)，并进行了最小化的适配。Chirpy 的所有功能在 hugo-theme-chirpy 中均可使用（不过在 Hugo 框架下，部分功能的操作方式可能有所不同）。
+[Chirpy](https://github.com/cotes2020/jekyll-theme-chirpy) 是一个基于 [Jekyll](https://jekyllrb.com/) 的博客主题。由于 Jekyll 的设计限制，它本身不支持国际化（i18n），需要依赖第三方插件来实现 i18n 功能。为了让 Chirpy 在不依赖第三方插件的情况下支持 i18n，[hugo-theme-chirpy](https://github.com/kewalaka/hugo-theme-chirpy) 项目将 Chirpy 主题迁移至 [Hugo](https://gohugo.io/)，并进行了最小化的适配。Chirpy 的所有功能在 hugo-theme-chirpy 中均可使用（不过在 Hugo 框架下，部分功能的操作方式可能有所不同）。
 
 跟随示例站点的文章，快速搭建一个免费的个人博客吧！
 ## 功能特点

--- a/exampleSite/content/post/2019-08-09-getting-started/index.en.md
+++ b/exampleSite/content/post/2019-08-09-getting-started/index.en.md
@@ -33,7 +33,7 @@ This approach simplifies upgrades, isolates unnecessary files, and is perfect fo
 This approach is convenient for modifying features or UI design, but presents challenges during upgrades. So don't try this unless you are familiar with Jekyll and plan to heavily modify this theme.
 
 1. Sign in to GitHub.
-2. [Fork the theme repository](https://github.com/geekifan/jekyll-theme-chirpy/fork).
+2. [Fork the theme repository](https://github.com/kewalaka/jekyll-theme-chirpy/fork).
 3. Name the new repository `<username>.github.io`, replacing `username` with your lowercase GitHub username.
 
 ## Setting up the Environment
@@ -101,7 +101,7 @@ To customize the stylesheet, copy the theme's {{< filepath src="assets/css/jekyl
 
 Static assets configuration was introduced in version `5.1.0`. The CDN of the static assets is defined in {{< filepath src="_data/origin/cors.ymll">}}. You can replace some of them based on the network conditions in the region where your website is published.
 
-If you prefer to self-host the static assets, modify {{< filepath src="config/_default/params.toml">}} and turn `self_host` on. The static files are from [geekifan/chirpy-static-assets](https://github.com/geekifan/chirpy-static-assets#readme) which is a fork of [cotes2020/chirpy-static-assets](https://github.com/cotes2020/chirpy-static-assets#readme) with minimal changes to make it work with hugo.
+If you prefer to self-host the static assets, modify {{< filepath src="config/_default/params.toml">}} and turn `self_host` on. The static files are from [kewalaka/chirpy-static-assets](https://github.com/kewalaka/chirpy-static-assets#readme) which is a fork of [cotes2020/chirpy-static-assets](https://github.com/cotes2020/chirpy-static-assets#readme) with minimal changes to make it work with hugo.
 
 ## Deployment
 
@@ -147,7 +147,7 @@ $ JEKYLL_ENV=production bundle exec jekyll b
 Unless you specified the output path, the generated site files will be placed in the {{< filepath src="_site" >}}folder of the project's root directory. Upload these files to your target server.
 
 [nodejs]: https://nodejs.org/
-[starter]: https://github.com/geekifan/chirpy-starter
+[starter]: https://github.com/kewalaka/chirpy-starter
 [pages-workflow-src]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow
 [docker-desktop]: https://www.docker.com/products/docker-desktop/
 [docker-engine]: https://docs.docker.com/engine/install/

--- a/exampleSite/data/authors/en.yaml
+++ b/exampleSite/data/authors/en.yaml
@@ -1,3 +1,3 @@
 yifan:
   name: Yifan
-  url: https://github.com/geekifan
+  url: https://github.com/kewalaka

--- a/exampleSite/data/authors/zh-CN.yaml
+++ b/exampleSite/data/authors/zh-CN.yaml
@@ -1,3 +1,3 @@
 yifan:
   name: 一凡
-  url: https://github.com/geekifan
+  url: https://github.com/kewalaka

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/kewalaka/hugo-theme-chirpy
 
-go 1.24.2
+go 1.25.1
 
-require github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect
+require (
+	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect
+	github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 // indirect
+	github.com/kewalaka/chirpy-static-assets v0.0.0-20250913013117-3f583e2dc6f3 // indirect
+	github.com/twbs/bootstrap v5.3.6+incompatible // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,5 @@
-module github.com/geekifan/hugo-theme-chirpy
+module github.com/kewalaka/hugo-theme-chirpy
 
 go 1.24.2
 
-require (
-	github.com/geekifan/chirpy-static-assets v0.0.0-20250507021825-887e490b15f2 // indirect
-	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect
-	github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 // indirect
-	github.com/twbs/bootstrap v5.3.6+incompatible // indirect
-)
+require github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,4 @@
-github.com/geekifan/chirpy-static-assets v0.0.0-20250507021825-887e490b15f2 h1:r/j8ns7StZlMJeDd5mRPZ5RgogdsegvrVHPr2y955/U=
-github.com/geekifan/chirpy-static-assets v0.0.0-20250507021825-887e490b15f2/go.mod h1:F58Ey9QK/tEgIxwcQSqAgV4ZA24mCb714B58D4Syv/0=
 github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 h1:L6+F22i76xmeWWwrtijAhUbf3BiRLmpO5j34bgl1ggU=
 github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400/go.mod h1:uekq1D4ebeXgduLj8VIZy8TgfTjrLdSl6nPtVczso78=
-github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 h1:GZxx4Hc+yb0/t3/rau1j8XlAxLE4CyXns2fqQbyqWfs=
 github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000/go.mod h1:mFberT6ZtcchrsDtfvJM7aAH2bDKLdOnruUHl0hlapI=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
-github.com/twbs/bootstrap v5.3.6+incompatible h1:efmXVyq839m5QQ0+JBUdQQ1TrmoBqvQ5kRhUueKsH+4=
-github.com/twbs/bootstrap v5.3.6+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,9 @@
 github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 h1:L6+F22i76xmeWWwrtijAhUbf3BiRLmpO5j34bgl1ggU=
 github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400/go.mod h1:uekq1D4ebeXgduLj8VIZy8TgfTjrLdSl6nPtVczso78=
+github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 h1:GZxx4Hc+yb0/t3/rau1j8XlAxLE4CyXns2fqQbyqWfs=
 github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000/go.mod h1:mFberT6ZtcchrsDtfvJM7aAH2bDKLdOnruUHl0hlapI=
+github.com/kewalaka/chirpy-static-assets v0.0.0-20250913013117-3f583e2dc6f3 h1:ET4rq1Oo8wfhjvYVBu4yUFGmO0QELWOLqQ5DcoEGdgo=
+github.com/kewalaka/chirpy-static-assets v0.0.0-20250913013117-3f583e2dc6f3/go.mod h1:aQlpH3fJwaUJbb+TrvjzvUXdh3Z5AVOT7Ilnp83sqsA=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.6+incompatible h1:efmXVyq839m5QQ0+JBUdQQ1TrmoBqvQ5kRhUueKsH+4=
+github.com/twbs/bootstrap v5.3.6+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.toml
+++ b/hugo.toml
@@ -22,7 +22,7 @@ defaultContentLanguageInSubdir = false
   path = "github.com/gohugoio/hugo-mod-bootstrap-scss/v5"
 
 [[module.imports]]
-  path = "github.com/geekifan/chirpy-static-assets"
+  path = "github.com/kewalaka/chirpy-static-assets"
 
 [[module.imports.mounts]]
   source = "."

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -32,7 +32,7 @@
         data-bs-toggle="tooltip"
         data-bs-placement="top"
         title="v%s"
-        href="https://github.com/geekifan/hugo-theme-chirpy"
+        href="https://github.com/kewalaka/hugo-theme-chirpy"
         target="_blank"
         rel="noopener"
       >Chirpy</a>` .Site.Params.theme_version -}}


### PR DESCRIPTION
This pull request updates all references from `geekifan` to `kewalaka` throughout the project. The changes ensure that links, documentation, configuration, and dependencies now point to the correct repository and author under the `kewalaka` namespace. This helps maintain consistency and accuracy after the project’s migration.

Repository and dependency updates:
* Changed the Go module path in `go.mod` to `github.com/kewalaka/hugo-theme-chirpy` and updated the static assets dependency to use `kewalaka/chirpy-static-assets`.
* Updated the Hugo module import path for static assets in `hugo.toml` to `github.com/kewalaka/chirpy-static-assets`.

Documentation and link corrections:
* Updated all links in `README.md`, including starter template, license, demo, and wiki, to point to the `kewalaka` repositories. Added credit to `geekifan` for the Hugo port. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R63)
* Changed references in documentation files (`index.en.md`, `index.zh-CN.md`, and `2019-08-09-getting-started/index.en.md`) to use `kewalaka` links for theme, starter, and static assets. [[1]](diffhunk://#diff-ad7a7368bf55295a9a08fddc6cae82cda92038b4af149ce387ccfc41d382991aL13-R13) [[2]](diffhunk://#diff-e98eb054feeebcc2334099c2228eb1905fa2b6b48552b47f6f0118c74775622eL13-R13) [[3]](diffhunk://#diff-41bc2cac91e61d87f08a5be27a0bb4ffe7419c72bab9bbf0c6bcb6f98d8f6099L36-R36) [[4]](diffhunk://#diff-41bc2cac91e61d87f08a5be27a0bb4ffe7419c72bab9bbf0c6bcb6f98d8f6099L104-R104) [[5]](diffhunk://#diff-41bc2cac91e61d87f08a5be27a0bb4ffe7419c72bab9bbf0c6bcb6f98d8f6099L150-R150)

Author and social profile updates:
* Updated author URLs in `params.toml`, `authors/en.yaml`, and `authors/zh-CN.yaml` to point to `https://github.com/kewalaka`. [[1]](diffhunk://#diff-8b2e5d757c1d24d93c6691ffa8510b1c4f25f09e2770d53604e815d6182a619bL10-R10) [[2]](diffhunk://#diff-05332dcc65d19359d9c0cc27678c1bfc2122744d973febb26de23a07d83198d1L3-R3) [[3]](diffhunk://#diff-0c60ef6e8502f433b215eca52be7d32bf92546a35e2d7bf5096a3daee922b01cL3-R3)

Footer and theme branding:
* Changed footer link in `footer.html` to reference the new `kewalaka/hugo-theme-chirpy` repository.